### PR TITLE
Bar colors

### DIFF
--- a/McGillStartupFair.iOS/AppDelegate.cs
+++ b/McGillStartupFair.iOS/AppDelegate.cs
@@ -26,7 +26,9 @@ namespace McGillStartupFair.iOS
         {
             UINavigationBar.Appearance.BarTintColor = new UIColor(245 / 255f, 246 / 255f, 247 / 255f, 1.0f);
             UINavigationBar.Appearance.TintColor = new UIColor(90 / 255f, 36 / 255f, 191 / 255f, 1.0f);
+#if ENABLE_TEST_CLOUD
             Xamarin.Calabash.Start();
+#endif
             global::Xamarin.Forms.Forms.Init();
             Xamarin.FormsMaps.Init();
             LoadApplication(new App());

--- a/McGillStartupFair.iOS/McGillStartupFair.iOS.csproj
+++ b/McGillStartupFair.iOS/McGillStartupFair.iOS.csproj
@@ -26,6 +26,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -41,7 +42,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
+    <DefineConstants>__IOS__;__MOBILE__;__UNIFIED__;DEBUG;ENABLE_TEST_CLOUD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchArch>ARM64</MtouchArch>

--- a/McGillStartupFair/HomePage.xaml
+++ b/McGillStartupFair/HomePage.xaml
@@ -1,11 +1,16 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TabbedPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="McGillStartupFair.HomePage" BarBackgroundColor="Red"
+<TabbedPage xmlns="http://xamarin.com/schemas/2014/forms"
+            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+            x:Class="McGillStartupFair.HomePage"
             xmlns:local="clr-namespace:McGillStartupFair"
-            >
+            SelectedTabColor="#5a24bf"
+            BarBackgroundColor="#e5e5e5"
+            UnselectedTabColor="#d4c4f2"
+            BarTextColor="#5a24bf">
 
-<local:Employers IconImageSource="company.png"/>
-<local:info Icon="info.png"/>
-<local:FloorPlan IconImageSource="fplan.png"/>
-<local:Favorites IconImageSource="heart.png"/>
+<local:Employers Title="Employers" IconImageSource="company.png"/>
+<local:info Title="Info" Icon="info.png"/>
+<local:FloorPlan Title="Floor Plan" IconImageSource="fplan.png"/>
+<local:Favorites Title="Favorites" IconImageSource="heart.png"/>
 
 </TabbedPage>

--- a/McGillStartupFair/Views/CompanyView.xaml.cs
+++ b/McGillStartupFair/Views/CompanyView.xaml.cs
@@ -29,5 +29,7 @@ namespace McGillStartupFair.Views
             BindingContext = this;
 
         }
+
+        private void Favourites_Clicked(object sender, EventArgs args) { }
     }
 }


### PR DESCRIPTION
Hello Alex, was able to find the issue.
The colors were being overridden directly inside the TabbedPage. I updated the colors directly from the XAML —which I had forgotten was now a possibility, much easier now— so you can easily change the colors set there to the ones you want.

Also, as I mention in the first commit for this pull request, I took the liberty of adding some conditional to your AppDelegate and a Debug constant to the iOS project, which will prevent Test Cloud from being enabled on release.

Hope this was helpful!